### PR TITLE
TASK-05-01: Functioning Email Sender

### DIFF
--- a/Backend/LinkedOut/credentials/views.py
+++ b/Backend/LinkedOut/credentials/views.py
@@ -1,9 +1,16 @@
 from django.contrib.auth.models import User, Group
 from rest_framework import viewsets, permissions
+from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.request import Request
 
 from LinkedOut.credentials.models import Applicant, Education, Experience, Recruiter
 from .serializers import ApplicantSerializer, EducationSerializer, ExperienceSerializer, RecruiterSerializer, UserSerializer, GroupSerializer
+
+from email.message import EmailMessage
+import ssl
+import smtplib
+import re
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -58,4 +65,43 @@ class ExperienceViewSet(viewsets.ModelViewSet):
     serializer_class = ExperienceSerializer
     # permission_classes = [permissions.IsAuthenticated]
 
+class SendEmailView(APIView):
+
+    def get(self, request: Request):
+        email_regex = re.compile(r"([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+")
+        query_params = request.query_params
+
+        if not query_params['firstname']:
+            return Response("Missing first name!")
+        first_name = query_params['firstname']
+        
+        if not query_params['lastname']:
+            return Response("Missing last name!")
+        last_name = query_params['lastname']
+        
+        if not query_params['company']:
+            return Response({"status": "Missing company name!"})
+        company = query_params['company']
+
+        recipient = query_params['email']
+        if re.fullmatch(email_regex, recipient):
+            sender = 'linkedoutnotifications'
+            password = 'lkcpvpfjtfwvnuwp'
+
+            email = EmailMessage()
+            email['From'] = sender
+            email['To'] = recipient
+            email['Subject'] = "You got an Interview!"
+
+            email.set_content(f"Hello {first_name} {last_name}\nYou got an interview from {company}! Head over to LinkedOut to respond!")
+
+            context = ssl.create_default_context()
+
+            with smtplib.SMTP_SSL('smtp.gmail.com', 465, context= context) as smtp:
+                smtp.login(sender, password)
+                smtp.sendmail(sender, recipient, email.as_string())
+            return Response("Successfully sent email!")
+        
+        else:
+            return Response("Recipient's email address does not have a valid email structure, or was not provided")
  

--- a/Backend/LinkedOut/credentials/views.py
+++ b/Backend/LinkedOut/credentials/views.py
@@ -72,11 +72,11 @@ class SendEmailView(APIView):
         query_params = request.query_params
 
         if not query_params['firstname']:
-            return Response("Missing first name!")
+            return Response({"status":"Missing first name!"})
         first_name = query_params['firstname']
         
         if not query_params['lastname']:
-            return Response("Missing last name!")
+            return Response({"status":"Missing last name!"})
         last_name = query_params['lastname']
         
         if not query_params['company']:
@@ -100,8 +100,8 @@ class SendEmailView(APIView):
             with smtplib.SMTP_SSL('smtp.gmail.com', 465, context= context) as smtp:
                 smtp.login(sender, password)
                 smtp.sendmail(sender, recipient, email.as_string())
-            return Response("Successfully sent email!")
+            return Response({"status":"Successfully sent email!"})
         
         else:
-            return Response("Recipient's email address does not have a valid email structure, or was not provided")
+            return Response({"status":"Recipient's email address does not have a valid email structure, or was not provided"})
  

--- a/Backend/LinkedOut/urls.py
+++ b/Backend/LinkedOut/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 from django.urls import include, path
 from rest_framework import routers
 from rest_framework.authtoken import views
-from LinkedOut.credentials.views import ApplicantViewSet, EducationViewSet, ExperienceViewSet, RecruiterViewSet, UserViewSet, GroupViewSet
+from LinkedOut.credentials.views import ApplicantViewSet, EducationViewSet, ExperienceViewSet, RecruiterViewSet, UserViewSet, GroupViewSet, SendEmailView
 from LinkedOut.JobListings.views import JobViewSet
 from django.contrib import admin
 
@@ -29,12 +29,12 @@ router.register(r'educations', EducationViewSet)
 router.register(r'experiences', ExperienceViewSet)
 router.register(r'applicants', ApplicantViewSet)
 router.register(r'recruiters', RecruiterViewSet)
-
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 
 urlpatterns = [
     path('api/v1/', include(router.urls)),
+    path('api/v1/send-email', SendEmailView.as_view()),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('api-token-auth/', views.obtain_auth_token),
     path('admin/', admin.site.urls),

--- a/Backend/LinkedOut/urls.py
+++ b/Backend/LinkedOut/urls.py
@@ -34,7 +34,7 @@ router.register(r'recruiters', RecruiterViewSet)
 
 urlpatterns = [
     path('api/v1/', include(router.urls)),
-    path('api/v1/send-email', SendEmailView.as_view()),
+    path('send-email', SendEmailView.as_view()),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('api-token-auth/', views.obtain_auth_token),
     path('admin/', admin.site.urls),


### PR DESCRIPTION
The email sender must contain the following 4 query parameters in the URL, else it won't work:

firstname: Candidate's first name
lastname: Candidate's last name
email: Candidate's email
company: Recruiter's company name

It should be noted that this endpoint only supports sending an email to a singular person, so it should be used only when accepting one Candidate at a time