### PR TITLE
Made emails more dynamic

### DIFF
--- a/Backend/LinkedOut/credentials/views.py
+++ b/Backend/LinkedOut/credentials/views.py
@@ -162,6 +162,14 @@ class SendEmailView(APIView):
             return Response({"status": "Missing company name!"})
         company = query_params['company']
 
+        if not query_params['subject']:
+            return Response({"status": "Missing subject!"})
+        subject = query_params['subject']
+
+        if not query_params['message']:
+            return Response({"status": "Missing Message!"})
+        message = query_params['message']
+
         recipient = query_params['email']
         if re.fullmatch(email_regex, recipient):
             sender = 'linkedoutnotifications'
@@ -170,9 +178,20 @@ class SendEmailView(APIView):
             email = EmailMessage()
             email['From'] = sender
             email['To'] = recipient
-            email['Subject'] = "You got an Interview!"
+            email['Subject'] = subject
 
-            email.set_content(f"Hello {first_name} {last_name}\nYou got an interview from {company}! Head over to LinkedOut to respond!")
+            #       Allowing frontend to use these keywords to fetch the real value in their message query parameter
+            #       ex:    Hello {firstname} {lastname}, You got a job!
+            #       If the firstname and last name given was Jerry Smith, this would evaluate to:
+            #       Hello Jerry Smith, You got a job!
+
+            message = message.replace("{firstname}", first_name)
+            message = message.replace("{lastname}", last_name)
+            message = message.replace("{company}", company)
+            message = message.replace("{subject}", subject)
+            message = message.replace("{email}", recipient)
+
+            email.set_content(message)
 
             context = ssl.create_default_context()
 
@@ -183,4 +202,4 @@ class SendEmailView(APIView):
         
         else:
             return Response({"status":"Recipient's email address does not have a valid email structure, or was not provided"})
- 
+        


### PR DESCRIPTION
For the emails now, you need to have the following query parameters in the url:

firstname: The first name of the recipient
lastname: The last name of the recipient
company: The company(recruiter's company) sending the email to the recipient
subject: The subject of the email
message: The content of the email
email: The email of the recipient

So an example of a valid endpoint call would look like this:
http://localhost:8000/send-email?firstname=Liam&lastname=Daigle&company=Google&message=Testing%0A0FirstName:%20{firstname}%20LastName:%20{lastname}%20Subject:%20{subject}%20Email:%20{email}%20Company:%20{company}&email=liam.daigle@gmail.com&subject=%20TestingSubject

where every parameter is seperated by an & symbol.

I have allowed for the frontend to access the information they put in the query parameters for the message by surrounding the parameter you want to use by curly braces in the string. You can see this in the example above.

{firstname} : returns the firstname of the recipient
{lastname}: returns the lastname of the recipient
{subject}: returns the subject of the email
{company}: returns the company who sent the email
{email}: returns the email of the recipient

Note that if you are having trouble creating a new line in the email, try using %0A instead of a space to indicate a newline. This is the way that the string query parameter reads a new line.

So for example: message=This is a test%0AThis is a new line
would return:

This is a test
This is a new line